### PR TITLE
Fix snapcraft.yaml

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,7 +13,7 @@ confinement: classic
 
 apps:
   exa:
-    command: exa
+    command: bin/exa
 
 parts:
   exa:
@@ -23,3 +23,4 @@ parts:
       - libgit2-24
       - cmake
       - libz-dev
+      - make


### PR DESCRIPTION
Fixes failure to cleanbuild in the snap:

>CMake Error: CMake was unable to find a build program corresponding to "Unix Makefiles". CMAKE_MAKE_PROGRAM is not set. You probably need to select a different build tool.